### PR TITLE
Updating spark installation in collab

### DIFF
--- a/contents/spark-setup/README.md
+++ b/contents/spark-setup/README.md
@@ -27,6 +27,7 @@ Install dependencies.
 
 ``` sh
 # install java libs and spark.
+!apt update > /dev/null
 !apt-get install openjdk-8-jdk-headless -qq > /dev/null
 !wget -q https://downloads.apache.org/spark/spark-3.1.1/spark-3.1.1-bin-hadoop3.2.tgz
 !tar xf spark-3.1.1-bin-hadoop3.2.tgz


### PR DESCRIPTION
The `openjdk-8-jdk-headless` package is not available in collab unless we first update the apt repositories. Added the missing instruction.